### PR TITLE
Add GolangCI Lint Configuration as per Issue #4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,50 @@
+run:
+  timeout: 5m
+  go: "1.22"
+
+linters-settings:
+  gocritic:
+    enabled-tags:
+    - performance
+  lll:
+    line-length: 200
+  misspell:
+    locale: US
+  staticcheck:
+    go: "1.22"
+
+linters:
+  disable-all: true
+  enable:
+    - durationcheck
+    - exportloopref
+    - errcheck
+    - errorlint
+    - exhaustive
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - gosec
+    - ineffassign
+    - makezero
+    - misspell
+    - nilerr
+    - revive
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unused
+    - whitespace
+  # Run with --fast=false for more extensive checks (enables all linters)
+  fast: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+severity:
+  default-severity: error


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does:**
This PR addresses Issue #4 by introducing a .golangci.yml configuration file inspired by the one used in [kubernetes-sigs/secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/.golangci.yml). 

**Changes from CSI Driver version**
- Use go version 1.22
- Remove default comments 
- Remove csi specific exceptions 

**Which issue(s) this PR fixes:**
Fixes #4 

**Local Testing:**
- Ran `golangci-lint run` locally on a similar project containing go code.
