### PR TITLE
test: add e2e vap tests

### DIFF
--- a/config/validatingadmissionpolicies/update_owners_check_old_object.yaml
+++ b/config/validatingadmissionpolicies/update_owners_check_old_object.yaml
@@ -45,6 +45,6 @@ spec:
     expression: "params.data.exists_one(x, params.data[x] == oldObject.type) ? true : false"
   validations:
   - expression: "variables.allowedSecretTypes == true && variables.hasOneSecretSyncOwner == true"
-    message: "Only secrets with one secret sync owner and with types defined in the config_allow_secret_types configmap are allowed"
+    message: "Only secrets with one secret sync owner and with types defined in the allowedSecretTypes list can be updated by the controller"
     messageExpression: "string(params.data.controllerName)  + ' has failed to ' +  string(request.operation) + ' old secret with ' + string(object.type) + ' type ' + 'in the ' + string(request.namespace) + ' namespace. The controller can only update secrets in the allowed types list with a single secretsync owner.'"
     reason: "Forbidden"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/update_owners_check_old_object.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/update_owners_check_old_object.yaml
@@ -24,7 +24,7 @@ spec:
     expression: {{ include "chartname.secretTypesList" .Values.validatingAdmissionPolicies.allowedSecretTypes | quote }}
   validations:
   - expression: "variables.allowedSecretTypes == true && variables.hasOneSecretSyncOwner == true"
-    message: "Only secrets with one secret sync owner and with types defined in the config_allow_secret_types configmap are allowed"
+    message: "Only secrets with one secret sync owner and with types defined in the allowedSecretTypes list can be updated by the controller"
     messageExpression: "string(params.data.controllerName)  + ' has failed to ' +  string(request.operation) + ' old secret with ' + string(object.type) + ' type ' + 'in the ' + string(request.namespace) + ' namespace. The controller can only update secrets in the allowed types list with a single secrets-store-sync-controller owner.'"
     reason: "Forbidden"
 {{- end -}}

--- a/test/bats/README.md
+++ b/test/bats/README.md
@@ -26,3 +26,7 @@ This doc lists the different Secret Sync scenarios tested as part of CI.
 | Deploy `e2e-providerspc` SecretSync CRD                                                                | ✔️  |
 | Deploy SecretProviderClass and SecretSync in different namespaces and check that no secret is created  | ✔️  |
 | Deploy SecretProviderClass and SecretSync, ensure secret is created, then delete SecretSync and verify | ✔️  |
+| Validating Admission Policy blocks secret creation when its type is not in the allowed list            | ✔️  |
+| Validating Admission Policy blocks secret creation when its type is in the disallowed list             | ✔️  |
+| Validating Admission Policy blocks secretsync creation when an annotation is invalid                   | ✔️  |
+| Validating Admission Policy blocks secretsync creation when a label is invalid                         | ✔️  |

--- a/test/bats/helpers.bash
+++ b/test/bats/helpers.bash
@@ -81,6 +81,118 @@ compare_owner_count() {
   [[ "$(kubectl get secret "${secret}" -n "${namespace}" -o json | jq '.metadata.ownerReferences | length')" -eq $ownercount ]]
 }
 
+create_namespace() {
+  local namespace="$1"
+  kubectl create namespace "${namespace}" --dry-run=client -o yaml | kubectl apply -f -
+}
+
+deploy_and_wait_for_resource() {
+  local namespace="$1"
+  local yaml_file="$2"
+  local resource_name="$3"
+  local resource_type="$4"
+  local wait_time="${5:-$WAIT_TIME}"
+  local sleep_time="${6:-$SLEEP_TIME}"
+
+  kubectl apply -n "$namespace" -f "$yaml_file"
+  wait_for_process "$wait_time" "$sleep_time" "kubectl get ${resource_type}/${resource_name} -n ${namespace} -o yaml | grep ${resource_name}"
+}
+
+verify_secretsync_status() {
+  local name="$1"
+  local namespace="$2"
+  local expected_message="$3"
+  local expected_reason="$4"
+  local expected_status="$5"
+  local timeout=60
+  local interval=5
+  local elapsed=0
+
+  while (( elapsed < timeout )); do
+    # Attempt to fetch the status
+    local status
+    status=$(kubectl get secretsyncs.secret-sync.x-k8s.io/"$name" -n "${namespace}" -o jsonpath='{.status.conditions[0]}' 2>/dev/null || echo "")
+
+    # If the status is not empty, perform verification
+    if [[ -n "$status" ]]; then
+      local message
+      message=$(echo "$status" | jq -r .message)
+      
+      local reason
+      reason=$(echo "$status" | jq -r .reason)
+      
+      local status_value
+      status_value=$(echo "$status" | jq -r .status)
+
+      if [[ "${message}" == "${expected_message}" && "${reason}" == "${expected_reason}" && "${status_value}" == "${expected_status}" ]]; then
+        echo "Status verified successfully for SecretSync: ${name} in namespace: ${namespace}"
+        return 0
+      else
+        echo "Status: ${status} found but does not match expected values for SecretSync: ${name} in namespace: ${namespace}"
+        return 1
+      fi
+    fi
+
+    # Sleep and increment elapsed time only if the status was empty
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+
+  echo "Timeout reached while waiting for SecretSync status to become available for: $name in namespace: $namespace"
+  return 1
+}
+
+
+verify_secret_not_exists() {
+  local name="$1"
+  local namespace="$2"
+  cmd="kubectl get secret ${name} -n ${namespace}"
+  run $cmd
+  assert_failure
+}
+
+deploy_spc_ss_verify_conditions() {
+  local provider_yaml="$1"
+  local sync_yaml="$2"
+  local sync_name="$3"
+  local expected_message="$4"
+  local expected_reason="$5"
+  local expected_status="$6"
+  local spc_namespace="${7:-default}"
+  local ss_namespace="${8:-default}"
+  
+  # Deploy SecretProviderClass and wait for it
+  deploy_and_wait_for_resource "${spc_namespace}" "${provider_yaml}" "e2e-providerspc" "secretproviderclasses.secrets-store.csi.x-k8s.io"
+
+  # Deploy SecretSync and wait for it
+  deploy_and_wait_for_resource "${ss_namespace}" "${sync_yaml}" "${sync_name}" "secretsyncs.secret-sync.x-k8s.io"
+
+  # Verify SecretSync status
+  verify_secretsync_status "${sync_name}" "${ss_namespace}" "${expected_message}" "${expected_reason}" "${expected_status}"
+
+  # Verify secret is not created
+  verify_secret_not_exists "${sync_name}" "${ss_namespace}"
+}
+
+deploy_spc_ss_expect_failure() {
+  local spc_yaml="$1"
+  local ss_yaml="$2"
+  local sync_name="$3"
+  local expected_message="$4"
+  local spc_namespace="${5:-default}"
+  local ss_namespace="${6:-default}"
+
+  # Deploy SecretProviderClass and wait for it
+  deploy_and_wait_for_resource "${spc_namespace}" "${spc_yaml}" "e2e-providerspc" "secretproviderclasses.secrets-store.csi.x-k8s.io"
+
+  # Deploy SecretSync and expect it to fail
+  output=$(kubectl apply -n "${ss_namespace}" -f "${ss_yaml}" 2>&1 || true)
+  [[ "${output}" == *"${expected_message}"* ]]
+
+  # Verify secret is not created
+  verify_secret_not_exists "${sync_name}" "${ss_namespace}"
+}
+
 wait_for_process() {
   wait_time="$1"
   sleep_time="$2"

--- a/test/bats/tests/e2e_provider/api_credential_secretsync.yaml
+++ b/test/bats/tests/e2e_provider/api_credential_secretsync.yaml
@@ -1,0 +1,12 @@
+apiVersion: secret-sync.x-k8s.io/v1alpha1
+kind: SecretSync
+metadata:
+  name: my-custom-api-secret  # this is the name of the secret that will be created
+spec:
+  serviceAccountName: default
+  secretProviderClassName: e2e-providerspc
+  secretObject:
+    type: example.com/api-credentials
+    data:
+      - sourcePath: foo # name of the object in the SecretProviderClass
+        targetKey:  bar # name of the key in the Kubernetes secret

--- a/test/bats/tests/e2e_provider/invalid_annotation_key_secretsync.yaml
+++ b/test/bats/tests/e2e_provider/invalid_annotation_key_secretsync.yaml
@@ -1,0 +1,14 @@
+apiVersion: secret-sync.x-k8s.io/v1alpha1
+kind: SecretSync
+metadata:
+  name: sse2einvalidannotationssecret  # this is the name of the secret that will be created
+spec:
+  serviceAccountName: default
+  secretProviderClassName: e2e-providerspc
+  secretObject:
+    type: Opaque
+    data:
+      - sourcePath: foo # name of the object in the SecretProviderClass
+        targetKey:  bar # name of the key in the Kubernetes secret
+    annotations:
+       "my.annotation/with_invalid_characters!": default

--- a/test/bats/tests/e2e_provider/invalid_annotation_value_secretsync.yaml
+++ b/test/bats/tests/e2e_provider/invalid_annotation_value_secretsync.yaml
@@ -1,0 +1,14 @@
+apiVersion: secret-sync.x-k8s.io/v1alpha1
+kind: SecretSync
+metadata:
+  name: sse2einvalidannotationssecret
+spec:
+  serviceAccountName: default
+  secretProviderClassName: e2e-providerspc
+  secretObject:
+    type: Opaque
+    data:
+      - sourcePath: foo
+        targetKey: bar
+    annotations:
+      my.annotation: "ThisValueExceedsTheSixtyThreeCharacterLimitAndShouldFailValidation"

--- a/test/bats/tests/e2e_provider/invalid_label_key_secretsync.yaml
+++ b/test/bats/tests/e2e_provider/invalid_label_key_secretsync.yaml
@@ -1,0 +1,14 @@
+apiVersion: secret-sync.x-k8s.io/v1alpha1
+kind: SecretSync
+metadata:
+  name: sse2einvalidlabelsecret
+spec:
+  serviceAccountName: default
+  secretProviderClassName: e2e-providerspc
+  secretObject:
+    type: Opaque
+    data:
+      - sourcePath: foo
+        targetKey: bar
+    labels:
+        "invalid/key_with_invalid_characters!": "validValue"

--- a/test/bats/tests/e2e_provider/invalid_label_value_secretsync.yaml
+++ b/test/bats/tests/e2e_provider/invalid_label_value_secretsync.yaml
@@ -1,0 +1,14 @@
+apiVersion: secret-sync.x-k8s.io/v1alpha1
+kind: SecretSync
+metadata:
+  name: sse2einvalidlabelsecret
+spec:
+  serviceAccountName: default
+  secretProviderClassName: e2e-providerspc
+  secretObject:
+    type: Opaque
+    data:
+      - sourcePath: foo
+        targetKey: bar
+    labels:
+       "valid-key": "-invalid"

--- a/test/bats/tests/e2e_provider/service_account_token_secretsync.yaml
+++ b/test/bats/tests/e2e_provider/service_account_token_secretsync.yaml
@@ -1,0 +1,14 @@
+apiVersion: secret-sync.x-k8s.io/v1alpha1
+kind: SecretSync
+metadata:
+  name: sse2eserviceaccountsecret  # this is the name of the secret that will be created
+spec:
+  serviceAccountName: default
+  secretProviderClassName: e2e-providerspc
+  secretObject:
+    type: kubernetes.io/service-account-token
+    data:
+      - sourcePath: foo # name of the object in the SecretProviderClass
+        targetKey:  bar # name of the key in the Kubernetes secret
+    annotations:
+      kubernetes.io/service-account.name: default


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

<!--
Add one of the following kinds:
-->
/kind feature
<!--
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds Validating Admission Policy end-to-end (E2E) tests. 
It also corrects an error message printed when a vap triggers by removing a reference to a configmap 
**Which issue(s) this PR fixes**:
Fixes #47 

**Special notes for your reviewer**:
Please review the added BATS tests and ensure they cover the intended scenarios correctly.
**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests