### PR TITLE
ci: updates timeout for staging image build

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,7 +14,7 @@
 
 REGISTRY?=docker.io
 IMAGE_NAME=controller
-# to trigger staging image build we should update the IMAGE_VERSION while cutting a release.
+# to trigger staging image build we should update the IMAGE_VERSION while cutting a release
 IMAGE_VERSION?=v0.0.1
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,7 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
-timeout: 600s
+timeout: 5400s
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

Fixes timeout during staging image build - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/secrets-store-sync-controller-push-image/1826723352539041792

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests


/cc @aramase 