### PR TITLE
fix: fix kubeVersion string in charts to validate GKE version

### DIFF
--- a/manifest_staging/charts/secrets-store-sync-controller/Chart.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: secrets-store-sync-controller
 version: 0.0.1
 appVersion: v0.0.1
-kubeVersion: ">=1.27.0"
+kubeVersion: ">=1.27.0-0"
 description: A Helm chart to install the Secrets Store Sync Controller and its associated resources inside a Kubernetes cluster.


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/secrets-store-sync-controller/issues/80


When I tried to install the controller on GKE, I got error that it is incompatible with GKE cluster.

On comparing with driver code, I found following difference which solved my issue.
https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/Chart.yaml#L5