### PR TITLE
docs: update controller image name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ As the controller is still under development, the helm chart is not available in
    ```shell
    VERSION=e2e make docker-build
    
-   kind load docker-image --name sync-controller secrets-store-sync-controller:e2e
+   kind load docker-image --name sync-controller controller:e2e
    ```
 
 1. Configure the provider container


### PR DESCRIPTION
Fixing issue # https://github.com/kubernetes-sigs/secrets-store-sync-controller/issues/86

As per 

https://github.com/kubernetes-sigs/secrets-store-sync-controller/blob/main/Makefile#L172

https://github.com/kubernetes-sigs/secrets-store-sync-controller/blob/main/Makefile#L106-L110

https://github.com/kubernetes-sigs/secrets-store-sync-controller/blob/main/Makefile#L53C1-L54

The README.md file provides instructions for deploying the controller (https://github.com/kubernetes-sigs/secrets-store-sync-controller?tab=readme-ov-file#deploy-the-controller). However, there are discrepancies between the instructions and the actual outcomes of the commands.

Specifically, when executing the command: VERSION=e2e make docker-build The resulting Docker image is named controller:e2e instead of secrets-store-sync-controller:e2e as stated in the documentation. This inconsistency between the documentation and the actual behavior may lead to confusion for users attempting to deploy the controller.

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
