### PR TITLE
feat: introduce external secret refresh capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Dockerfile.cross
 *.swo
 *~
 /_output/
+.DS_Store

--- a/api/v1alpha1/secretsync_types.go
+++ b/api/v1alpha1/secretsync_types.go
@@ -118,6 +118,14 @@ type SecretSyncSpec struct {
 	// +kubebuilder:validation:Pattern=^[A-Za-z0-9]([-A-Za-z0-9]+([-._a-zA-Z0-9]?[A-Za-z0-9])*)?
 	// +optional
 	ForceSynchronization string `json:"forceSynchronization,omitempty"`
+
+	// RefreshInterval specifies the duration to wait between external secret refresh.
+	// If unspecified, the controller will not automatically refresh the secret.
+	// Minimum value is 10 seconds.
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=^([0-9]+(\\.[0-9]+)?(s|m|h))+$
+	RefreshInterval *metav1.Duration `json:"refreshInterval,omitempty"`
 }
 
 // SecretSyncStatus defines the observed state of the secret synchronization process.

--- a/charts/secrets-store-sync-controller/crds/secret-sync.x-k8s.io_secretsyncs.yaml
+++ b/charts/secrets-store-sync-controller/crds/secret-sync.x-k8s.io_secretsyncs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: secretsyncs.secret-sync.x-k8s.io
 spec:
@@ -46,6 +46,12 @@ spec:
                   Apply operation. https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts
                 maxLength: 253
                 pattern: ^[A-Za-z0-9]([-A-Za-z0-9]+([-._a-zA-Z0-9]?[A-Za-z0-9])*)?
+                type: string
+              refreshInterval:
+                description: RefreshInterval specifies the duration to wait between external secret refresh.
+                  If unspecified, the controller will not automatically refresh the secret.
+                  Minimum value is 10 seconds.
+                pattern: ^([0-9]+(\\.[0-9]+)?(s|m|h))+$
                 type: string
               secretObject:
                 description: secretObject specifies the configuration for the synchronized

--- a/config/crd/bases/secret-sync.x-k8s.io_secretsyncs.yaml
+++ b/config/crd/bases/secret-sync.x-k8s.io_secretsyncs.yaml
@@ -52,6 +52,13 @@ spec:
                 maxLength: 253
                 pattern: ^[A-Za-z0-9]([-A-Za-z0-9]+([-._a-zA-Z0-9]?[A-Za-z0-9])*)?
                 type: string
+              refreshInterval:
+                description: |-
+                  RefreshInterval specifies the duration to wait between external secret refresh.
+                  If unspecified, the controller will not automatically refresh the secret.
+                  Minimum value is 10 seconds.
+                pattern: ^([0-9]+(\\.[0-9]+)?(s|m|h))+$
+                type: string
               secretObject:
                 description: secretObject specifies the configuration for the synchronized
                   Kubernetes secret object.


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR introduces periodic polling capability for external secrets by adding a new `RefreshInterval` field to SecretSync CRD. Currently, the SecretSync controller only updates secrets when the SecretSync object changes. This enhancement allows the controller to periodically check for changes in external secret providers (like Azure Key Vault) and automatically update the Kubernetes secrets when the external source changes.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #83

**Special notes for your reviewer**:
- Adds `RefreshInterval` field to SecretSync CRD
- Implements periodic reconciliation logic
- Adds requeue mechanism to handle periodic polls
- Updates controller logic to handle refresh intervals

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
