### PR TITLE
fix: update the hash generation logic

### DIFF
--- a/pkg/util/secretutil/secret_test.go
+++ b/pkg/util/secretutil/secret_test.go
@@ -445,6 +445,16 @@ func TestGenerateSHAFromSecret(t *testing.T) {
 			data2:            map[string][]byte{"key2": []byte("value2"), "key1": []byte("value1")},
 			expectedSHAMatch: true,
 		},
+		{
+			name: "different keys with the same concatenated result but should not match",
+			data1: map[string][]byte{
+				"key1": []byte("=value1"),
+			},
+			data2: map[string][]byte{
+				"key1=": []byte("value1"),
+			},
+			expectedSHAMatch: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
/kind bug

Fix the hash generation logic to prevent hash collision with different maps as input. This can be caused because of the concatenation logic.

The test added in https://github.com/kubernetes-sigs/secrets-store-sync-controller/commit/990c8939015afc67ae1d243bcabae46d80b304e0 shows the bug in the current logic.
```bash
=== RUN   TestGenerateSHAFromSecret/different_keys_with_the_same_concatenated_result_but_should_not_match
    secret_test.go:468: 
        	Error Trace:	/Users/anishramasekar/go/src/sigs.k8s.io/secrets-store-sync-controller/pkg/util/secretutil/secret_test.go:468
        	Error:      	Not equal: 
        	            	expected: false
        	            	actual  : true
        	Test:       	TestGenerateSHAFromSecret/different_keys_with_the_same_concatenated_result_but_should_not_match
--- FAIL: TestGenerateSHAFromSecret/different_keys_with_the_same_concatenated_result_but_should_not_match (0.00s)

Expected :false
Actual   :true
```

/assign enj