### PR TITLE
ci: add area/dependency label for dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     commit-message:
       prefix: "chore"
     labels:
+      - "area/dependency"
       - "ok-to-test"
 
   - package-ecosystem: docker
@@ -16,6 +17,7 @@ updates:
     commit-message:
       prefix: "chore"
     labels:
+      - "area/dependency"
       - "ok-to-test"
 
   - package-ecosystem: "gomod"
@@ -25,6 +27,7 @@ updates:
     commit-message:
       prefix: "chore"
     labels:
+      - "area/dependency"
       - "ok-to-test"
 
   - package-ecosystem: "gomod"
@@ -44,4 +47,5 @@ updates:
         - "k8s.io/*"
         - "sigs.k8s.io/*"
     labels:
+      - "area/dependency"
       - "ok-to-test"


### PR DESCRIPTION
I'm explicitly configuring it to use the same label that Dependabot applies by default. If a custom label is specified in the config, Dependabot doesn't add the default labels.

(xref: https://github.com/kubernetes/release/blob/b28854edebcb345c31260b53510368725225b079/.github/dependabot.yml#L8) for other places we do this.