### PR TITLE
chore: update to go 1.24.5

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.24.2@sha256:1ecc479bc712a6bdb56df3e346e33edcc141f469f82840bab9f4bc2bc41bf91d AS builder
+FROM golang:1.24.5@sha256:14fd8a55e59a560704e5fc44970b301d00d344e45d6b914dda228e09f359a088 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/secrets-store-sync-controller
 
-go 1.24.2
+go 1.24.5
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/secrets-store-sync-controller/hack/tools
 
-go 1.24.2
+go 1.24.5
 
 require github.com/golangci/golangci-lint v1.64.8
 


### PR DESCRIPTION
/triage accepted
/assign enj