### PR TITLE
chore: bump version to v0.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Update this value when you upgrade the version of your project.
-VERSION ?= v0.0.1
+VERSION ?= v0.0.2
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io
 IMAGE_NAME=controller
 # to trigger staging image build we should update the IMAGE_VERSION while cutting a release.
-IMAGE_VERSION?=v0.0.1
+IMAGE_VERSION?=v0.0.2
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Bump version to v0.0.2 to trigger image build.

/triage accepted
/assign @enj 