### PR TITLE
chore: bump engineerd/setup-kind to the actual release tag commit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,8 @@ Add one of the following kinds:
 
 **What this PR does / why we need it**:
 
-**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
+**Which issue(s) this PR fixes**:
+<!-- Optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged -->
 Fixes #
 
 **Special notes for your reviewer**:

--- a/.github/workflows/e2e-provider-tests.yaml
+++ b/.github/workflows/e2e-provider-tests.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Kubectl
         uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
       - name: Setup Kind
-        uses: engineerd/setup-kind@71e45b960fc8dd50b4aeabf6eb6ef2ca0920b4c1 # v0.6.2
+        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc # v0.6.2
         with:
           version: "v0.29.0"
           image: "kindest/node:${{ matrix.KUBERNETES_VERSION }}"


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:
The E2E provider test action was broken because dependabot chose the wrong commit to bump the `setup-kind` action to.

See the logs here: https://github.com/kubernetes-sigs/secrets-store-sync-controller/actions/runs/22343876011/job/64653383909#step:8:14

---

The PR also fixes the PR template so that one does not have to manually remove the text after `**What this PR does / why we need it**:` every time they open a PR.

**Which issue(s) this PR fixes**:
\-

**Special notes for your reviewer**:

