### PR TITLE
chore: use the stable API for VAPs everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,6 @@ The helm chart for the controller has validating admission policies that are ava
 
 Before you begin, ensure the [following](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/#before-you-begin).
 
-If you're creating a kind cluster, here's a sample config:
-
-```bash
-cat <<EOF | kind create cluster --name sync-controller --image kindest/node:v1.29.2 --config=-
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  ValidatingAdmissionPolicy: true
-runtimeConfig:
-  admissionregistration.k8s.io/v1beta1: true
-EOF
-```
-
 ### Deploy the controller
 
 As the controller is still under development, the helm chart is not available in the public repository. You can deploy the controller from the source code by following these steps:

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_create_update_secrets_type.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_create_update_secrets_type.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "secrets-store-sync-controller-create-update-policy-binding"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_create_update_token_request_deny.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_create_update_token_request_deny.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "secrets-store-sync-controller-create-update-token-deny-policy-binding"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_delete_secrets.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_delete_secrets.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "secrets-store-sync-controller-delete-policy-binding"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_update_owners_check_old_object.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_update_owners_check_old_object.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "secrets-store-sync-controller-update-check-oldobject-policy-binding"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_update_secrets_based_on_label.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_update_secrets_based_on_label.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "secrets-store-sync-controller-update-label-policy-binding"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_validate_annotation_format_secret_sync.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_validate_annotation_format_secret_sync.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "secrets-store-sync-controller-validate-annotation-policy-binding"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_validate_label_format_secret_sync.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_validate_label_format_secret_sync.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "secrets-store-sync-controller-validate-label-policy-binding"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_validate_token_config.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/VAPB_validate_token_config.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "secrets-store-sync-controller-validate-token-policy-binding"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/_helpers.tpl
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/_helpers.tpl
@@ -78,20 +78,3 @@ Generate a comma-separated string from a list.
 {{- end -}}
 {{- join ", " $audiences -}}
 {{- end -}}
-
-{{/*
-Determine the api version for the validating admission policies.
-*/}}
-{{- define "secrets-store-sync-controller.admissionApiVersion" -}}
-{{- if semverCompare "~1.27.0-0" .Capabilities.KubeVersion.Version -}}
-apiVersion: admissionregistration.k8s.io/v1alpha1
-{{- else if semverCompare "~1.28.0-0" .Capabilities.KubeVersion.Version -}}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- else if semverCompare "~1.29.0-0" .Capabilities.KubeVersion.Version -}}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- else if semverCompare "^1.30.x-0" .Capabilities.KubeVersion.Version -}}
-apiVersion: admissionregistration.k8s.io/v1
-{{- else -}}
-apiVersion: unsupported-validating-admission-api-version
-{{- end }}
-{{- end -}}

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/create_update_secrets_types.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/create_update_secrets_types.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "secrets-store-sync-controller-create-update-policy"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/create_update_token_request_deny.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/create_update_token_request_deny.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "secrets-store-sync-controller-create-update-token-deny-policy"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/delete_secrets.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/delete_secrets.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "secrets-store-sync-controller-delete-policy"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/update_owners_check_old_object.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/update_owners_check_old_object.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "secrets-store-sync-controller-update-check-oldobject-policy"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/update_secrets_based_on_label.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/update_secrets_based_on_label.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "secrets-store-sync-controller-update-label-policy"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/validate_annotation_format_secret_sync.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/validate_annotation_format_secret_sync.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "secrets-store-sync-controller-validate-annotation-policy"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/validate_label_format_secret_sync.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/validate_label_format_secret_sync.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "secrets-store-sync-controller-validate-label-policy"

--- a/manifest_staging/charts/secrets-store-sync-controller/templates/validate_token_config.yaml
+++ b/manifest_staging/charts/secrets-store-sync-controller/templates/validate_token_config.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validatingAdmissionPolicies.applyPolicies -}}
-{{ include "secrets-store-sync-controller.admissionApiVersion" . }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "secrets-store-sync-controller-validate-token-policy"


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We no longer support any k8s version that has less than stable VAP APIs.

**Which issue(s) this PR fixes**:
\-

**Special notes for your reviewer**:
\-
