### PR TITLE
release notes: use github-native release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+changelog:
+  exclude:
+    labels:
+      - release-note-none
+  categories:
+    - title: "⚠️ Breaking Changes"
+      labels:
+        - release-note-action-required
+    - title: "Features 🌈"
+      labels:
+        - kind/feature
+    - title: "Bug Fixes 🐞"
+      labels:
+        - kind/bug
+        - kind/regression
+    - title: "API Changes"
+      labels:
+        - kind/api-change
+    - title: "Documentation 📘"
+      labels:
+        - kind/documentation
+        - documentation
+    - title: "Deprecation"
+      labels:
+        - kind/deprecation
+    - title: "Testing 💚"
+      labels:
+        - kind/failing-test
+        - kind/flake
+    - title: "Cleanup & Maintenance 🔧"
+      labels:
+        - kind/cleanup
+        - area/dependency
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,28 +8,4 @@ release:
     ## {{.Tag}} - {{ time "2006-01-02" }}
 changelog:
   disable: false
-  groups:
-    - title: Bug Fixes 🐞
-      regexp: ^.*fix[(\\w)]*:+.*$
-    - title: Build 🏭
-      regexp: ^.*build[(\\w)]*:+.*$
-    - title: Code Refactoring 💎
-      regexp: ^.*refactor[(\\w)]*:+.*$
-    - title: Code Style 🎶
-      regexp: ^.*style[(\\w)]*:+.*$
-    - title: Continuous Integration 💜
-      regexp: ^.*ci[(\\w)]*:+.*$
-    - title: Documentation 📘
-      regexp: ^.*docs[(\\w)]*:+.*$
-    - title: Features 🌈
-      regexp: ^.*feat[(\\w)]*:+.*$
-    - title: Maintenance 🔧
-      regexp: ^.*chore[(\\w)]*:+.*$
-    - title: Performance Improvements 🚀
-      regexp: ^.*perf[(\\w)]*:+.*$
-    - title: Revert Change ◀️
-      regexp: ^.*revert[(\\w)]*:+.*$
-    - title: Security Fix 🛡️
-      regexp: ^.*security[(\\w)]*:+.*$
-    - title: Testing 💚
-      regexp: ^.*test[(\\w)]*:+.*$
+  use: github-native


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The release notes goreleaser generates require the patch authors to use semantic commit
messages which is both annoying and it steals characters from what's considered a reasonable
commit message size.

The past two releases were missing a few important changes because of that.

We're already tagging our PRs with labels that can be used to nicely distinguish the changes made into different sections. Use the github-native way of generate release notes in goreleaser.

/cc @aramase
