### PR TITLE
link-check: depend on a version that fixes SHA digests for its deps

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -29,7 +29,7 @@ jobs:
       with:
         persist-credentials: false
     - name: linkspector
-      uses: umbrelladocs/action-linkspector@37c85bcde51b30bf929936502bac6bfb7e8f0a4d # v1.4.1
+      uses: umbrelladocs/action-linkspector@1a59b2a2845679edd69f18de00d4c2b3d4a00428 # master with pinned deps; TODO: change to a release when available
 
       with:
         reporter: github-pr-review


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Fixes link-check to be runnable with the current repo policies.
