### PR TITLE
Standardize controller logging on structured klog

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	secretsstorecsiv1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
@@ -45,7 +45,6 @@ import (
 
 var (
 	scheme                  = runtime.NewScheme()
-	setupLog                = ctrl.Log.WithName("setup")
 	metricsAddr             = flag.String("metrics-bind-address", ":8085", "The address the metric endpoint binds to.")
 	enableLeaderElection    = flag.Bool("leader-elect", false, "Enable leader election for controller manager. "+"Enabling this will ensure there is only one active controller manager.")
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace for leader election")
@@ -67,18 +66,18 @@ func init() {
 }
 
 func runMain() error {
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
+	klog.InitFlags(nil)
 	flag.Parse()
+	defer klog.Flush()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	// Bridge controller-runtime's logger to klog so the manager and other
+	// controller-runtime internals emit structured logs through klog as well.
+	ctrl.SetLogger(klog.Background())
 
 	if *versionInfo {
 		versionErr := version.PrintVersion()
 		if versionErr != nil {
-			setupLog.Error(versionErr, "failed to print version")
+			klog.ErrorS(versionErr, "failed to print version")
 			return versionErr
 		}
 		return nil
@@ -97,7 +96,7 @@ func runMain() error {
 		LeaderElectionNamespace: *leaderElectionNamespace,
 	})
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
+		klog.ErrorS(err, "unable to start manager")
 		return err
 	}
 
@@ -127,23 +126,23 @@ func runMain() error {
 		Audiences:       audiences,
 		EventRecorder:   record.NewBroadcaster().NewRecorder(scheme, corev1.EventSource{Component: "secret-sync-controller"}),
 	}).SetupWithManager(mgr, *rotationPollInterval); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SecretSync")
+		klog.ErrorS(err, "unable to create controller", "controller", "SecretSync")
 		return err
 	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
+		klog.ErrorS(err, "unable to set up health check")
 		return err
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
+		klog.ErrorS(err, "unable to set up ready check")
 		return err
 	}
 
-	setupLog.Info("starting manager")
+	klog.InfoS("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
+		klog.ErrorS(err, "problem running manager")
 		return err
 	}
 

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"k8s.io/klog/v2"
 
 	secretsyncv1alpha1 "sigs.k8s.io/secrets-store-sync-controller/api/v1alpha1"
 )
@@ -69,8 +69,6 @@ var AllowedStringsToDisplayConditionErrorMessage = []string{
 }
 
 func (r *SecretSyncReconciler) updateStatusConditions(ctx context.Context, ss *secretsyncv1alpha1.SecretSync, conditionType string, conditionStatus metav1.ConditionStatus, conditionReason, conditionMessage string, shouldUpdateStatus bool) {
-	logger := log.FromContext(ctx)
-
 	if ss.Status.Conditions == nil {
 		ss.Status.Conditions = []metav1.Condition{}
 	}
@@ -82,7 +80,7 @@ func (r *SecretSyncReconciler) updateStatusConditions(ctx context.Context, ss *s
 		Message: conditionMessage,
 	}
 
-	logger.V(10).Info("Adding new condition", "newConditionType", conditionType, "conditionReason", conditionReason)
+	klog.V(10).InfoS("Adding new condition", "newConditionType", conditionType, "conditionReason", conditionReason)
 	meta.SetStatusCondition(&ss.Status.Conditions, condition)
 
 	if !shouldUpdateStatus {
@@ -90,10 +88,10 @@ func (r *SecretSyncReconciler) updateStatusConditions(ctx context.Context, ss *s
 	}
 
 	if err := r.Client.Status().Update(ctx, ss); err != nil {
-		logger.Error(err, "Failed to update status", "condition", condition)
+		klog.ErrorS(err, "Failed to update status", "condition", condition)
 	}
 
-	logger.V(10).Info("Updated status", "condition", condition)
+	klog.V(10).InfoS("Updated status", "condition", condition)
 }
 
 func (r *SecretSyncReconciler) initConditions(ctx context.Context, ss *secretsyncv1alpha1.SecretSync) error {

--- a/internal/controller/secretsync_controller.go
+++ b/internal/controller/secretsync_controller.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	"golang.org/x/crypto/pbkdf2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,12 +36,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -109,13 +108,12 @@ type SecretSyncReconciler struct {
 //+kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasses,verbs=get;list;watch
 
 func (r *SecretSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-	logger.Info("Reconciling SecretSync", "namespace", req.NamespacedName.String())
+	klog.InfoS("Reconciling SecretSync", "namespace", req.NamespacedName.String())
 
 	// get the secret sync object
 	ss := &secretsyncv1alpha1.SecretSync{}
 	if err := r.Get(ctx, req.NamespacedName, ss); err != nil {
-		logger.Error(err, "unable to fetch SecretSync")
+		klog.ErrorS(err, "unable to fetch SecretSync")
 		return ctrl.Result{}, err
 	}
 
@@ -128,7 +126,7 @@ func (r *SecretSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if len(ss.Status.Conditions) < 2 {
 		if err := r.initConditions(ctx, ss); err != nil {
-			logger.Error(err, "failed to initialize SecretSync object conditions", "namespace", ss.Namespace, "name", ss.Name)
+			klog.ErrorS(err, "failed to initialize SecretSync object conditions", "namespace", ss.Namespace, "name", ss.Name)
 			return ctrl.Result{}, err
 		}
 	}
@@ -145,12 +143,12 @@ func (r *SecretSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// get the secret provider class object
 	spc := &secretsstorecsiv1.SecretProviderClass{}
 	if err := r.Get(ctx, client.ObjectKey{Name: ss.Spec.SecretProviderClassName, Namespace: req.Namespace}, spc); err != nil {
-		logger.Error(err, "failed to get SecretProviderClass", "name", ss.Spec.SecretProviderClassName)
+		klog.ErrorS(err, "failed to get SecretProviderClass", "name", ss.Spec.SecretProviderClassName)
 		r.updateStatusConditions(ctx, ss, conditionType, metav1.ConditionFalse, ConditionReasonControllerSpcError, fmt.Sprintf("failed to get SecretProviderClass %q: %v", ss.Spec.SecretProviderClassName, err), true)
 		return ctrl.Result{}, err
 	}
 
-	datamap, reason, err := r.fetchSecretsFromProvider(ctx, logger, spc, ss)
+	datamap, reason, err := r.fetchSecretsFromProvider(ctx, spc, ss)
 	if err != nil {
 		r.updateStatusConditions(ctx, ss, conditionType, metav1.ConditionFalse, reason, fmt.Sprintf("fetching secrets from the provider failed: %v", err), true)
 		return ctrl.Result{}, err
@@ -159,7 +157,7 @@ func (r *SecretSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Compute the hash of the secret
 	syncHash, err := computeCurrentStateHash(datamap, spc, ss)
 	if err != nil {
-		logger.Error(err, "failed to compute state hash", "secretName", secretName) // TODO: could this leak secrets?
+		klog.ErrorS(err, "failed to compute state hash", "secretName", secretName) // TODO: could this leak secrets?
 		r.updateStatusConditions(ctx, ss, conditionType, metav1.ConditionFalse, ConditionReasonControllerSyncError, "failed to compute state hash", true)
 		return ctrl.Result{}, err
 	}
@@ -197,7 +195,7 @@ func (r *SecretSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Attempt to create or update the secret.
 	if err = r.serverSidePatchSecret(ctx, ss, datamap); err != nil {
-		logger.Error(err, "failed to patch secret", "secretName", secretName)
+		klog.ErrorS(err, "failed to patch secret", "secretName", secretName)
 
 		// Rollback to the previous hash and the previous last successful sync time.
 		ss.Status.SyncHash = prevSecretHash
@@ -213,7 +211,7 @@ func (r *SecretSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	logger.V(4).Info("Done... updated status", "syncHash", syncHash, "lastSuccessfulSyncTime", ss.Status.LastSuccessfulSyncTime)
+	klog.V(4).InfoS("Done... updated status", "syncHash", syncHash, "lastSuccessfulSyncTime", ss.Status.LastSuccessfulSyncTime)
 	return ctrl.Result{}, nil
 }
 
@@ -233,18 +231,17 @@ func (r *SecretSyncReconciler) validateLabelsAnnotations(
 
 func (r *SecretSyncReconciler) fetchSecretsFromProvider(
 	ctx context.Context,
-	logger logr.Logger,
 	spc *secretsstorecsiv1.SecretProviderClass,
 	ss *secretsyncv1alpha1.SecretSync,
 ) (map[string][]byte, string, error) {
 	providerName := string(spc.Spec.Provider)
 	providerClient, err := r.ProviderClients.Get(ctx, providerName)
 	if err != nil {
-		logger.Error(err, "failed to get provider client", "provider", providerName)
+		klog.ErrorS(err, "failed to get provider client", "provider", providerName)
 		return nil, ConditionReasonControllerSpcError, err
 	}
 
-	paramsJSON, reason, err := r.prepareCSIProviderParams(logger, spc, ss.Namespace, ss.Spec.ServiceAccountName)
+	paramsJSON, reason, err := r.prepareCSIProviderParams(spc, ss.Namespace, ss.Spec.ServiceAccountName)
 	if err != nil {
 		return nil, reason, err
 	}
@@ -253,14 +250,14 @@ func (r *SecretSyncReconciler) fetchSecretsFromProvider(
 	var secretsJSON []byte
 	secretsJSON, err = json.Marshal(secretRefData)
 	if err != nil {
-		logger.Error(err, "failed to marshal secret")
+		klog.ErrorS(err, "failed to marshal secret")
 		return nil, ConditionReasonControllerSyncError, err
 	}
 
 	oldObjectVersions := make(map[string]string)
 	_, files, err := provider.MountContent(ctx, providerClient, string(paramsJSON), string(secretsJSON), oldObjectVersions)
 	if err != nil {
-		logger.Error(err, "failed to get secrets from provider", "provider", providerName)
+		klog.ErrorS(err, "failed to get secrets from provider", "provider", providerName)
 		return nil, ConditionReasonFailedProviderError, err
 	}
 
@@ -268,7 +265,7 @@ func (r *SecretSyncReconciler) fetchSecretsFromProvider(
 	secretType := corev1.SecretType(secretObj.Type)
 	var datamap map[string][]byte
 	if datamap, err = secretutil.BuildKubeSecretData(secretObj.Data, secretType, files); err != nil {
-		logger.Error(err, "failed to get secret data", "secretName", ss.Name)
+		klog.ErrorS(err, "failed to get secret data", "secretName", ss.Name)
 		return nil, ConditionReasonRemoteSecretStoreFetchFailed, err
 	}
 
@@ -281,7 +278,6 @@ func (r *SecretSyncReconciler) fetchSecretsFromProvider(
 //
 // Returns JSON-serialized parameters, condition reason in case of an error, and the error itself.
 func (r *SecretSyncReconciler) prepareCSIProviderParams(
-	logger logr.Logger,
 	spc *secretsstorecsiv1.SecretProviderClass,
 	namespace,
 	saName string,
@@ -289,7 +285,7 @@ func (r *SecretSyncReconciler) prepareCSIProviderParams(
 	// get the service account token
 	serviceAccountTokenAttrs, err := token.SecretProviderServiceAccountTokenAttrs(r.TokenCache, namespace, saName, r.Audiences)
 	if err != nil {
-		logger.Error(err, "failed to get service account token", "name", saName)
+		klog.ErrorS(err, "failed to get service account token", "name", saName)
 
 		return nil, ConditionReasonControllerSyncError, err
 	}
@@ -306,7 +302,7 @@ func (r *SecretSyncReconciler) prepareCSIProviderParams(
 
 	paramsJSON, err := json.Marshal(parameters)
 	if err != nil {
-		logger.Error(fmt.Errorf("%T", err), "failed to marshal parameters")
+		klog.ErrorS(fmt.Errorf("%T", err), "failed to marshal parameters")
 		return nil, ConditionReasonControllerSyncError, fmt.Errorf("failed to marshal parameters: %T", err)
 	}
 
@@ -464,13 +460,12 @@ func (r *SecretSyncReconciler) providerPollingFunc(pollInterval time.Duration, i
 		ticker := time.NewTicker(pollInterval)
 		defer ticker.Stop()
 
-		logger := log.FromContext(ctx)
 		for {
 			select {
 			case <-ticker.C:
 				ssList := &secretsyncv1alpha1.SecretSyncList{}
 				if err := r.List(ctx, ssList); err != nil {
-					logger.Error(err, "failed to list SecretSyncs")
+					klog.ErrorS(err, "failed to list SecretSyncs")
 					continue
 				}
 				for idx := range ssList.Items {
@@ -487,7 +482,7 @@ func (r *SecretSyncReconciler) providerPollingFunc(pollInterval time.Duration, i
 		}
 
 	handle_context_done:
-		logger.Info("shutting down periodic resync")
+		klog.InfoS("shutting down periodic resync")
 		return nil
 	}
 }


### PR DESCRIPTION
/kind cleanup

**What this does**

Standardizes the controller's logging on structured klog (`klog.InfoS` / `klog.ErrorS` with key/value pairs, `klog.V(n)` for verbosity), matching the approach used in the [Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver).

**Why**

Addresses #13 ("Finalize on the logger used for the controller"). The codebase currently mixes logging approaches:
- `pkg/metrics`, `pkg/provider`, `pkg/token` already use `k8s.io/klog/v2` with structured `InfoS`/`ErrorS` calls.
- `cmd/main.go` used controller-runtime's zap logger.
- `internal/controller` (reconciler + conditions) used controller-runtime's logr via `log.FromContext`.

This PR converges everything on structured klog.

**Changes**
- `cmd/main.go`: register klog flags via `klog.InitFlags(nil)`, drop the zap options, and bridge controller-runtime's logger to klog with `ctrl.SetLogger(klog.Background())` so the manager's internal logs still flow through klog. The `setupLog` calls become `klog.InfoS`/`klog.ErrorS`.
- `internal/controller/secretsync_controller.go`: replace `log.FromContext`/logr usage with `klog.InfoS`/`klog.ErrorS` and `klog.V(n)`, preserving the existing verbosity levels (e.g. `V(4)`). The `logr.Logger` parameters threaded through `fetchSecretsFromProvider`/`prepareCSIProviderParams` are dropped since they're no longer needed.
- `internal/controller/conditions.go`: same conversion, preserving the `V(10)` levels.

No behavior or logic changes beyond the log calls; `go.mod`/`go.sum` are untouched (zap remains an indirect dependency via controller-runtime).

**Open question for maintainers**

Since this issue is about *finalizing* the logger, I want to confirm the direction. I've standardized on **klog** to match the CSI driver and the packages that already use it. The alternative would be to standardize the other way — on controller-runtime's `logr`/`log.FromContext` (which carries reconcile-request context automatically). I bridged controller-runtime to klog via `ctrl.SetLogger(klog.Background())` so its internals still log. Happy to flip the direction if you'd prefer logr — just let me know.

**Validation**
- `go build ./...` — pass
- `go test ./...` — pass
- `go vet ./...` — pass
- `gofmt -l` — clean
- `make lint` (golangci-lint v1.64.8) — pass, 0 issues

**DCO**: commit is signed off.
